### PR TITLE
Feature/user grouping

### DIFF
--- a/client/src/components/SurveyLandingPage.tsx
+++ b/client/src/components/SurveyLandingPage.tsx
@@ -220,7 +220,7 @@ export default function SurveyLandingPage({
           <img
             style={{
               minWidth: '130px',
-              maxWidth: '20%',
+              width: '10vw',
               position: !mediumWidth ? 'absolute' : 'static',
               left: !mediumWidth ? '0' : 'auto',
               bottom: 0,

--- a/client/src/components/admin/EditDocumentSection.tsx
+++ b/client/src/components/admin/EditDocumentSection.tsx
@@ -16,6 +16,7 @@ export default function EditDocumentSection({ section, onChange }: Props) {
       <FileUpload
         surveyId={activeSurvey.id}
         targetPath={[String(activeSurvey.id)]}
+        surveyGroups={activeSurvey.groups}
         value={
           !section.fileName
             ? null

--- a/client/src/components/admin/EditImageSection.tsx
+++ b/client/src/components/admin/EditImageSection.tsx
@@ -19,6 +19,7 @@ export default function EditImageSection({ section, onChange }: Props) {
       <FileUpload
         surveyId={activeSurvey.id}
         targetPath={[String(activeSurvey.id)]}
+        surveyGroups={activeSurvey.groups}
         value={
           !section.fileName
             ? null

--- a/client/src/components/admin/EditSurveyPage.tsx
+++ b/client/src/components/admin/EditSurveyPage.tsx
@@ -282,6 +282,7 @@ export default function EditSurveyPage() {
           <FileUpload
             surveyId={activeSurvey.id}
             targetPath={[String(activeSurvey.id)]}
+            surveyGroups={activeSurvey.groups}
             value={
               !page.sidebar.imageName
                 ? null

--- a/client/src/components/admin/FileUpload.tsx
+++ b/client/src/components/admin/FileUpload.tsx
@@ -15,6 +15,7 @@ interface Props {
   }[];
   onUpload: (file: { name: string; path: string[] }) => void;
   onDelete: (file: { name: string; path: string[] }) => void;
+  surveyGroups: string[];
 }
 
 export default function FileUpload({
@@ -23,6 +24,7 @@ export default function FileUpload({
   value,
   onDelete,
   surveyId,
+  surveyGroups,
 }: Props) {
   const { tr } = useTranslations();
   const { showToast } = useToasts();
@@ -34,6 +36,7 @@ export default function FileUpload({
     const fullFilePath = getFullFilePath(path, name);
     await fetch(`/api/file/${fullFilePath}`, {
       method: 'DELETE',
+      headers: { groups: JSON.stringify(surveyGroups) },
     });
   }
 

--- a/client/src/components/admin/SurveyImageList.tsx
+++ b/client/src/components/admin/SurveyImageList.tsx
@@ -268,6 +268,7 @@ export default function SurveyImageList({ imageType, ...props }: Props) {
       await fetch(getApiFilePath(imageType), {
         method: 'POST',
         body: formData,
+        headers: { groups: JSON.stringify(activeSurvey.groups) },
       });
       acceptedFiles.shift();
       getImages();

--- a/client/src/components/admin/SurveyList.tsx
+++ b/client/src/components/admin/SurveyList.tsx
@@ -95,6 +95,7 @@ export default function SurveyList() {
             setNewSurveyLoading(true);
             try {
               const newSurvey = await createNewSurvey();
+              setNewSurveyLoading(false);
               history.push(`/kyselyt/${newSurvey.id}`);
             } catch (error) {
               showToast({
@@ -102,7 +103,7 @@ export default function SurveyList() {
                 message: tr.SurveyList.errorCreatingNewSurvey,
               });
             } finally {
-              setNewSurveyLoading(false);
+              if (newSurveyLoading) setNewSurveyLoading(false);
             }
           }}
         >

--- a/client/src/stores/en.json
+++ b/client/src/stores/en.json
@@ -50,6 +50,8 @@
     "nameHelperText": "The name displayed on the survey URL-address. This can only include characters (a-z), numbers (0-9), hyphen (-) and underline (_).",
     "author": "Survey author / contact person",
     "authorUnit": "Survey author's / contact person's unit",
+    "authorizedGroups": "Authorized user groups",
+    "authorizedGroupsHelperText": "Users in these groups will have access to the survey.",
     "admins": "Survey admins",
     "userFetchFailed": "Failed to fetch users. Try again later.",
     "adminsHelperText": "Users besides the original author of the survey, who will have access to the survey answers and who can modify the survey.",

--- a/client/src/stores/fi.json
+++ b/client/src/stores/fi.json
@@ -50,6 +50,8 @@
     "nameHelperText": "Kyselyn URL-osoitteessa näkyvä nimi. Voi sisältää vain kirjaimia (a-z), numeroita (0-9) ja viivoja (- ja _).",
     "author": "Kyselyn laatija/yhteyshenkilö",
     "authorUnit": "Kyselyn laatijan yksikkö",
+    "authorizedGroups": "Luvitetut käyttäjäryhmät",
+    "authorizedGroupsHelperText": "Kyselyn näkevät vain valitut käyttäjäryhmät.",
     "admins": "Kyselyn ylläpitäjät",
     "userFetchFailed": "Käyttäjien haku epäonnistui. Yritä myöhemmin uudestaan.",
     "adminsHelperText": "Kyselyn alkuperäisen luojan lisäksi määriteltävät käyttäjät, jotka voivat katsella kyselyn vastauksia sekä muokata kyselyä.",

--- a/client/src/stores/se.json
+++ b/client/src/stores/se.json
@@ -50,6 +50,8 @@
     "nameHelperText": "Namnet som syns i undersökningens URL-adress. Kan innehålla endast bokstäver (a-z), siffror (0-9) och bindestreck (- och _).",
     "author": "Undersökningens författare/kontaktperson",
     "authorUnit": "Författarens enhet",
+    "authorizedGroups": "Auktoriserade grupper",
+    "authorizedGroupsHelperText": "Endast utvalda användargrupper kan se enkäten.",
     "admins": "Undersökningens administratörer",
     "userFetchFailed": "Misslyckades att hämta användare. Försök igen senare.",
     "adminsHelperText": "Användare som definieras förutom den ursprungliga skaparen av undersökningen, som kan se undersökningssvar och redigera undersökningen.",

--- a/interfaces/survey.d.ts
+++ b/interfaces/survey.d.ts
@@ -489,6 +489,10 @@ export interface Survey {
     top: { imagePath: string[]; imageName: string; altText?: string };
     bottom: { imagePath: string[]; imageName: string; altText?: string };
   };
+  /**
+   * User groups that can access the survey
+   */
+  groups: string[];
 }
 
 /**

--- a/interfaces/user.d.ts
+++ b/interfaces/user.d.ts
@@ -14,4 +14,8 @@ export interface User {
    * User's email address
    */
   email: string;
+  /**
+   * User's group ids
+   */
+  groups: string[];
 }

--- a/server/.template.env
+++ b/server/.template.env
@@ -48,3 +48,5 @@ EMAIL_SENDER_ADDRESS=<Sender address>
 EMAIL_SENDER_NAME=<Sender name>
 # This address will be used for creating a link to the application inside the message
 EMAIL_APP_URL=http://localhost:8080
+# Is user grouping enabled
+USER_GROUPING_ENABLED="true"

--- a/server/migrations/1713174587275_user-grouping.ts
+++ b/server/migrations/1713174587275_user-grouping.ts
@@ -1,0 +1,10 @@
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql(`
+  ALTER TABLE application.USER ADD COLUMN GROUPS text[] NOT NULL DEFAULT '{}'::TEXT[];
+  ALTER TABLE DATA.survey ADD COLUMN GROUPS text[] NOT NULL DEFAULT '{}'::TEXT[];
+  ALTER TABLE DATA.files ADD COLUMN GROUPS text[] NOT NULL DEFAULT '{}'::text[];`);
+}

--- a/server/src/auth/google-oauth.ts
+++ b/server/src/auth/google-oauth.ts
@@ -47,6 +47,7 @@ export function configureGoogleOAuth(app: Express) {
           id: profile.id,
           fullName: profile.displayName,
           email: profile._json.email,
+          groups: [],
         });
         return done(null, user);
       },

--- a/server/src/routes/answers.routes.ts
+++ b/server/src/routes/answers.routes.ts
@@ -4,7 +4,7 @@ import {
   getGeoPackageFile,
 } from '@src/application/answer';
 import { userCanEditSurvey } from '@src/application/survey';
-import { ensureAuthenticated } from '@src/auth';
+import { ensureAuthenticated, ensureSurveyGroupAccess } from '@src/auth';
 import { BadRequestError, ForbiddenError } from '@src/error';
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
@@ -19,6 +19,7 @@ const router = Router();
 router.get(
   '/:id/file-export/csv',
   ensureAuthenticated(),
+  ensureSurveyGroupAccess(),
   validateRequest([
     param('id').isNumeric().toInt().withMessage('ID must be a number'),
   ]),
@@ -47,6 +48,7 @@ router.get(
 router.get(
   '/:id/file-export/geopackage',
   ensureAuthenticated(),
+  ensureSurveyGroupAccess(),
   validateRequest([
     param('id').isNumeric().toInt().withMessage('ID must be a number'),
   ]),
@@ -73,6 +75,7 @@ router.get(
 router.get(
   '/:id/file-export/attachments',
   ensureAuthenticated(),
+  ensureSurveyGroupAccess(),
   validateRequest([
     param('id').isNumeric().toInt().withMessage('ID must be a number'),
   ]),

--- a/server/src/routes/user.routes.ts
+++ b/server/src/routes/user.routes.ts
@@ -12,7 +12,7 @@ router.get(
   '/',
   ensureAuthenticated(),
   asyncHandler(async (req, res) => {
-    const users = await getUsers();
+    const users = await getUsers(req.user.groups);
     res.json(users);
   }),
 );
@@ -32,7 +32,7 @@ router.get(
   ensureAuthenticated(),
   asyncHandler(async (req, res) => {
     // Exclude logged in user from response
-    const users = await getUsers([req.user.id]);
+    const users = await getUsers(req.user.groups, [req.user.id]);
     res.json(users);
   }),
 );


### PR DESCRIPTION
- Tweak landing page footer image scaling
- User grouping added (for Azure authentication)
  - Assigned user groups are received during login
  - Users have access only to surveys and files which are permitted for the user's group(s)
  - If a user has only one user group then created surveys are assigned to that user group
  - If a user has multiple user groups then appropriate survey groups can be selected when creating a new survey
  - Background images, thanks page images and margin images inherit group visibility from their parent survey