### PR TITLE
Show the loading spinner until the image is loaded

### DIFF
--- a/client/src/components/admin/SurveyImageList.tsx
+++ b/client/src/components/admin/SurveyImageList.tsx
@@ -500,8 +500,8 @@ export default function SurveyImageList({ imageType, ...props }: Props) {
                 <SurveyImageListItem
                   key={image.fileUrl}
                   image={image}
+                  src={imageSrc}
                   altText={imageAltText}
-                  limitToSvg={limitToSvg}
                   setImageDialogOpen={() => {
                     setImageDialogOpen((prev) => !prev);
                   }}

--- a/client/src/components/admin/SurveyImageList.tsx
+++ b/client/src/components/admin/SurveyImageList.tsx
@@ -502,9 +502,6 @@ export default function SurveyImageList({ imageType, ...props }: Props) {
                   image={image}
                   src={imageSrc}
                   altText={imageAltText}
-                  setImageDialogOpen={() => {
-                    setImageDialogOpen((prev) => !prev);
-                  }}
                   onClick={handleListItemClick}
                   onDelete={handleDeletingImage}
                 />

--- a/client/src/components/admin/SurveyImageList.tsx
+++ b/client/src/components/admin/SurveyImageList.tsx
@@ -500,8 +500,8 @@ export default function SurveyImageList({ imageType, ...props }: Props) {
                 <SurveyImageListItem
                   key={image.fileUrl}
                   image={image}
-                  src={imageSrc}
                   altText={imageAltText}
+                  limitToSvg={limitToSvg}
                   setImageDialogOpen={() => {
                     setImageDialogOpen((prev) => !prev);
                   }}

--- a/client/src/components/admin/SurveyImageList.tsx
+++ b/client/src/components/admin/SurveyImageList.tsx
@@ -15,7 +15,6 @@ import {
   Typography,
 } from '@mui/material';
 import ImageIcon from '@src/components/icons/ImageIcon';
-import CancelIcon from '@src/components/icons/CancelIcon';
 import { makeStyles } from '@mui/styles';
 import { useToasts } from '@src/stores/ToastContext';
 import { useSurvey } from '@src/stores/SurveyContext';
@@ -24,6 +23,7 @@ import { request } from '@src/utils/request';
 import React, { useEffect, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { getFileName } from '@src/utils/path';
+import SurveyImageListItem from './SurveyImageListItem';
 
 const useStyles = makeStyles((theme: Theme) => ({
   noImageBackground: {
@@ -46,12 +46,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   addImageIcon: {
     color: theme.palette.primary.main,
-  },
-  deleteImageIcon: {
-    position: 'absolute',
-    top: '5px',
-    left: '5px',
-    fontSize: '26px',
   },
 }));
 
@@ -503,30 +497,17 @@ export default function SurveyImageList({ imageType, ...props }: Props) {
             {images.map((image) => {
               const imageSrc = `data:image/${limitToSvg ? 'svg+xml' : ''};base64,${image.data}`;
               return (
-                <ImageListItem
-                  style={getImageBorderStyle(image)}
+                <SurveyImageListItem
                   key={image.fileUrl}
-                  onClick={() => handleListItemClick(image.fileUrl)}
-                >
-                  <CancelIcon
-                    color="error"
-                    className={classes.deleteImageIcon}
-                    onClick={async (event) =>
-                      await handleDeletingImage(event, image.fileUrl)
-                    }
-                  />
-                  <img
-                    src={imageSrc}
-                    srcSet={imageSrc}
-                    alt={
-                      imageAltText
-                        ? imageAltText
-                        : `survey-image-${getFileName(image.fileUrl)}`
-                    }
-                    loading="lazy"
-                    style={{ height: '100%', objectFit: 'contain' }}
-                  />
-                </ImageListItem>
+                  image={image}
+                  altText={imageAltText}
+                  limitToSvg={limitToSvg}
+                  setImageDialogOpen={() => {
+                    setImageDialogOpen((prev) => !prev);
+                  }}
+                  onClick={handleListItemClick}
+                  onDelete={handleDeletingImage}
+                />
               );
             })}
           </ImageList>

--- a/client/src/components/admin/SurveyImageListItem.tsx
+++ b/client/src/components/admin/SurveyImageListItem.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { File } from '@interfaces/survey';
+import { ImageListItem } from '@mui/material';
+import CancelIcon from '@src/components/icons/CancelIcon';
+import { getFileName } from '@src/utils/path';
+
+interface Props {
+  image: File;
+  altText: string;
+  limitToSvg?: boolean;
+  onClick: Function;
+  onDelete: Function;
+}
+
+export default function SurveyImageListItem(props: Props) {
+  const image = props.image;
+  const imageSrc = `data:image/${props.limitToSvg ? 'svg+xml' : ''};base64,${image.data}`;
+
+  return (
+    <ImageListItem>
+      <CancelIcon
+        color="error"
+        style={{
+          position: 'absolute',
+          top: '5px',
+          left: '5px',
+          fontSize: '26px',
+        }}
+        onClick={async (event: MouseEvent) =>
+          await props.onDelete(event, image.fileUrl)
+        }
+      />
+      <img
+        src={imageSrc}
+        srcSet={imageSrc}
+        alt={props.altText || `survey-image-${getFileName(image.fileUrl)}`}
+        loading="lazy"
+        style={{
+          height: '100%',
+          objectFit: 'contain',
+          cursor: 'pointer',
+        }}
+        onClick={() => props.onClick(image.fileUrl)}
+      />
+    </ImageListItem>
+  );
+}

--- a/client/src/components/admin/SurveyImageListItem.tsx
+++ b/client/src/components/admin/SurveyImageListItem.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
+import { useState } from 'react';
 import { File } from '@interfaces/survey';
-import { ImageListItem } from '@mui/material';
+import { ImageListItem, CircularProgress } from '@mui/material';
 import CancelIcon from '@src/components/icons/CancelIcon';
 import { getFileName } from '@src/utils/path';
 
@@ -13,6 +14,7 @@ interface Props {
 }
 
 export default function SurveyImageListItem(props: Props) {
+  const [isLoading, setIsLoading] = useState(true);
   const image = props.image;
   const imageSrc = `data:image/${props.limitToSvg ? 'svg+xml' : ''};base64,${image.data}`;
 
@@ -38,10 +40,26 @@ export default function SurveyImageListItem(props: Props) {
         style={{
           height: '100%',
           objectFit: 'contain',
+          visibility: isLoading ? 'hidden' : 'visible',
           cursor: 'pointer',
+        }}
+        onLoad={() => {
+          setIsLoading(false);
         }}
         onClick={() => props.onClick(image.fileUrl)}
       />
+      <span
+        style={{
+          position: 'absolute',
+          height: '100%',
+          width: '100%',
+          display: isLoading ? 'flex' : 'none',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <CircularProgress style={{ color: '#00a393' }} />
+      </span>
     </ImageListItem>
   );
 }

--- a/client/src/components/admin/SurveyImageListItem.tsx
+++ b/client/src/components/admin/SurveyImageListItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useState, useRef, useEffect } from 'react';
+import { useState } from 'react';
 import { File } from '@interfaces/survey';
 import { ImageListItem, CircularProgress } from '@mui/material';
 import CancelIcon from '@src/components/icons/CancelIcon';
@@ -7,31 +7,19 @@ import { getFileName } from '@src/utils/path';
 
 interface Props {
   image: File;
-  src: string;
   altText: string;
+  limitToSvg?: boolean;
   onClick: Function;
   onDelete: Function;
 }
 
 export default function SurveyImageListItem(props: Props) {
-  const [status, setStatus] = useState<'notVisible' | 'loading' | 'visible'>(
-    'notVisible',
-  );
+  const [isLoading, setIsLoading] = useState(true);
   const image = props.image;
-
-  const imgContainer = useRef(null);
-  useEffect(() => {
-    const observer = new IntersectionObserver((entries) => {
-      if (entries[0].isIntersecting) {
-        setStatus('loading');
-        observer.disconnect();
-      }
-    });
-    if (imgContainer?.current) observer.observe(imgContainer.current);
-  }, []);
+  const imageSrc = `data:image/${props.limitToSvg ? 'svg+xml' : ''};base64,${image.data}`;
 
   return (
-    <ImageListItem ref={imgContainer}>
+    <ImageListItem>
       <CancelIcon
         color="error"
         style={{
@@ -44,33 +32,28 @@ export default function SurveyImageListItem(props: Props) {
           await props.onDelete(event, image.fileUrl)
         }
       />
-      {status !== 'notVisible' && (
-        <img
-          src={props.src}
-          srcSet={props.src}
-          alt={props.altText || `survey-image-${getFileName(image.fileUrl)}`}
-          loading="lazy"
-          style={{
-            height: '100%',
-            objectFit: 'contain',
-            visibility: status === 'loading' ? 'hidden' : 'visible',
-            cursor: 'pointer',
-          }}
-          onLoad={() => {
-            setStatus('done');
-          }}
-          onError={() => {
-            setStatus('done');
-          }}
-          onClick={() => props.onClick(image.fileUrl)}
-        />
-      )}
+      <img
+        src={imageSrc}
+        srcSet={imageSrc}
+        alt={props.altText || `survey-image-${getFileName(image.fileUrl)}`}
+        loading="lazy"
+        style={{
+          height: '100%',
+          objectFit: 'contain',
+          visibility: isLoading ? 'hidden' : 'visible',
+          cursor: 'pointer',
+        }}
+        onLoad={() => {
+          setIsLoading(false);
+        }}
+        onClick={() => props.onClick(image.fileUrl)}
+      />
       <span
         style={{
           position: 'absolute',
           height: '100%',
           width: '100%',
-          display: status === 'loading' ? 'flex' : 'none',
+          display: isLoading ? 'flex' : 'none',
           alignItems: 'center',
           justifyContent: 'center',
         }}

--- a/client/src/components/admin/SurveyImageListItem.tsx
+++ b/client/src/components/admin/SurveyImageListItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { File } from '@interfaces/survey';
 import { ImageListItem, CircularProgress } from '@mui/material';
 import CancelIcon from '@src/components/icons/CancelIcon';
@@ -7,19 +7,31 @@ import { getFileName } from '@src/utils/path';
 
 interface Props {
   image: File;
+  src: string;
   altText: string;
-  limitToSvg?: boolean;
   onClick: Function;
   onDelete: Function;
 }
 
 export default function SurveyImageListItem(props: Props) {
-  const [isLoading, setIsLoading] = useState(true);
+  const [status, setStatus] = useState<'notVisible' | 'loading' | 'visible'>(
+    'notVisible',
+  );
   const image = props.image;
-  const imageSrc = `data:image/${props.limitToSvg ? 'svg+xml' : ''};base64,${image.data}`;
+
+  const imgContainer = useRef(null);
+  useEffect(() => {
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting) {
+        setStatus('loading');
+        observer.disconnect();
+      }
+    });
+    if (imgContainer?.current) observer.observe(imgContainer.current);
+  }, []);
 
   return (
-    <ImageListItem>
+    <ImageListItem ref={imgContainer}>
       <CancelIcon
         color="error"
         style={{
@@ -32,28 +44,33 @@ export default function SurveyImageListItem(props: Props) {
           await props.onDelete(event, image.fileUrl)
         }
       />
-      <img
-        src={imageSrc}
-        srcSet={imageSrc}
-        alt={props.altText || `survey-image-${getFileName(image.fileUrl)}`}
-        loading="lazy"
-        style={{
-          height: '100%',
-          objectFit: 'contain',
-          visibility: isLoading ? 'hidden' : 'visible',
-          cursor: 'pointer',
-        }}
-        onLoad={() => {
-          setIsLoading(false);
-        }}
-        onClick={() => props.onClick(image.fileUrl)}
-      />
+      {status !== 'notVisible' && (
+        <img
+          src={props.src}
+          srcSet={props.src}
+          alt={props.altText || `survey-image-${getFileName(image.fileUrl)}`}
+          loading="lazy"
+          style={{
+            height: '100%',
+            objectFit: 'contain',
+            visibility: status === 'loading' ? 'hidden' : 'visible',
+            cursor: 'pointer',
+          }}
+          onLoad={() => {
+            setStatus('done');
+          }}
+          onError={() => {
+            setStatus('done');
+          }}
+          onClick={() => props.onClick(image.fileUrl)}
+        />
+      )}
       <span
         style={{
           position: 'absolute',
           height: '100%',
           width: '100%',
-          display: isLoading ? 'flex' : 'none',
+          display: status === 'loading' ? 'flex' : 'none',
           alignItems: 'center',
           justifyContent: 'center',
         }}

--- a/client/src/components/admin/SurveyImageListItem.tsx
+++ b/client/src/components/admin/SurveyImageListItem.tsx
@@ -7,8 +7,8 @@ import { getFileName } from '@src/utils/path';
 
 interface Props {
   image: File;
+  src: string;
   altText: string;
-  limitToSvg?: boolean;
   onClick: Function;
   onDelete: Function;
 }
@@ -16,7 +16,6 @@ interface Props {
 export default function SurveyImageListItem(props: Props) {
   const [isLoading, setIsLoading] = useState(true);
   const image = props.image;
-  const imageSrc = `data:image/${props.limitToSvg ? 'svg+xml' : ''};base64,${image.data}`;
 
   return (
     <ImageListItem>
@@ -27,14 +26,15 @@ export default function SurveyImageListItem(props: Props) {
           top: '5px',
           left: '5px',
           fontSize: '26px',
+          cursor: 'pointer',
         }}
         onClick={async (event: MouseEvent) =>
           await props.onDelete(event, image.fileUrl)
         }
       />
       <img
-        src={imageSrc}
-        srcSet={imageSrc}
+        src={props.src}
+        srcSet={props.src}
         alt={props.altText || `survey-image-${getFileName(image.fileUrl)}`}
         loading="lazy"
         style={{
@@ -46,20 +46,25 @@ export default function SurveyImageListItem(props: Props) {
         onLoad={() => {
           setIsLoading(false);
         }}
+        onError={() => {
+          setIsLoading(false);
+        }}
         onClick={() => props.onClick(image.fileUrl)}
       />
-      <span
-        style={{
-          position: 'absolute',
-          height: '100%',
-          width: '100%',
-          display: isLoading ? 'flex' : 'none',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        <CircularProgress style={{ color: '#00a393' }} />
-      </span>
+      {isLoading && (
+        <span
+          style={{
+            position: 'absolute',
+            height: '100%',
+            width: '100%',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <CircularProgress style={{ color: '#00a393' }} />
+        </span>
+      )}
     </ImageListItem>
   );
 }


### PR DESCRIPTION
- Split survey image list images into their own components that hold information if they are loaded or not
- Display the load spinner until the image element has triggered either onLoad or onError events