### PR TITLE
Fixed survey admin selection being always disabled

### DIFF
--- a/client/src/components/admin/SurveyListItem.tsx
+++ b/client/src/components/admin/SurveyListItem.tsx
@@ -75,7 +75,12 @@ export default function SurveyListItem(props: Props) {
   const { url } = useRouteMatch();
   const { activeUser } = useUser();
 
-  const disableUsersAccessToSurvey = useMemo(() => activeUser?.id !== survey.authorId || survey.admins.includes(activeUser?.id), [activeUser, survey]);
+  const disableUsersAccessToSurvey = useMemo(
+    () =>
+      activeUser?.id !== survey.authorId &&
+      !survey.admins.includes(activeUser?.id),
+    [activeUser, survey],
+  );
 
   const surveyUrl = useMemo(() => {
     if (!survey.name) {
@@ -206,7 +211,11 @@ export default function SurveyListItem(props: Props) {
             justifyContent: 'flex-start',
           }}
         >
-          <Button component={NavLink} to={`${url}kyselyt/${survey.id}`} disabled={disableUsersAccessToSurvey}>
+          <Button
+            component={NavLink}
+            to={`${url}kyselyt/${survey.id}`}
+            disabled={disableUsersAccessToSurvey}
+          >
             {tr.SurveyList.editSurvey}
           </Button>
           {/* Allow publish only if it isn't yet published and has a name */}

--- a/client/src/themes/admin.ts
+++ b/client/src/themes/admin.ts
@@ -1,7 +1,7 @@
-import { createTheme } from '@mui/material/styles';
 import { fiFI } from '@mui/material/locale';
-import { buttonOverrides } from './survey';
+import { createTheme } from '@mui/material/styles';
 import { surveyCardOverrides, ubiColors, ubiElevated } from './common';
+import { buttonOverrides } from './survey';
 
 declare module '@mui/material/styles' {
   interface TypographyVariants {
@@ -21,18 +21,18 @@ declare module '@mui/material/Typography' {
 export let theme = createTheme(
   {
     typography: {
-      fontFamily: 'Nunito'
+      fontFamily: 'Nunito',
     },
     components: {
       ...surveyCardOverrides,
       ...buttonOverrides,
       ...ubiColors,
-      MuiAppBar:{
-        styleOverrides:{
+      MuiAppBar: {
+        styleOverrides: {
           root: {
             boxShadow: ubiElevated,
-          }
-        }
+          },
+        },
       },
       MuiTypography: {
         variants: [
@@ -71,6 +71,15 @@ export let theme = createTheme(
           h4: { color: '#000000DE' },
           h5: { color: '#000000DE' },
           h6: { color: '#000000DE' },
+        },
+      },
+      MuiChip: {
+        styleOverrides: {
+          root: {
+            '&.Mui-disabled': {
+              opacity: 0.8,
+            },
+          },
         },
       },
     },


### PR DESCRIPTION
- Use `UserContext` in `EditSurveyInfo` to get all users
- Refactored the way how survey admin selection works (show active user as a disabled chip if it was selected as the admin)
